### PR TITLE
chore: update cloudflared to 2026.5.0

### DIFF
--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,9 +1,10 @@
 import { VersionGraph } from '@start9labs/start-sdk'
 import { v2026_3_0 } from './v2026.3.0'
+import { v2026_5_0 } from './v2026.5.0'
 
 export const versionGraph = VersionGraph.of({
-  current: v2026_3_0,
-  other: [],
+  current: v2026_5_0,
+  other: [v2026_3_0],
 })
 
-export const CLOUDFLARED_VERSION = '2026.3.0'
+export const CLOUDFLARED_VERSION = '2026.5.0'

--- a/startos/versions/v2026.5.0.ts
+++ b/startos/versions/v2026.5.0.ts
@@ -1,0 +1,16 @@
+import { VersionInfo } from '@start9labs/start-sdk'
+
+export const v2026_5_0 = VersionInfo.of({
+  version: '2026.5.0:0',
+  releaseNotes: {
+    en_US: 'Updated to cloudflared 2026.5.0',
+    es_ES: 'Actualizado a cloudflared 2026.5.0',
+    de_DE: 'Auf cloudflared 2026.5.0 aktualisiert',
+    pl_PL: 'Zaktualizowano do cloudflared 2026.5.0',
+    fr_FR: 'Mis à jour vers cloudflared 2026.5.0',
+  },
+  migrations: {
+    up: async ({ effects }) => {},
+    down: async ({ effects }) => {},
+  },
+})


### PR DESCRIPTION
Updates cloudflared to upstream version 2026.5.0.