### PR TITLE
feat: flatten routes directly under zone in Managed Public Routes action

### DIFF
--- a/startos/actions/managedOverview.ts
+++ b/startos/actions/managedOverview.ts
@@ -89,7 +89,7 @@ function getZoneGroups(
 
     return group(`${i18n('DNS Zone')}: ${zone.zoneName}`, [
       single(i18n('Zone ID'), zone.zoneId, null, true),
-      group(i18n('Application Routes'), routeGroups),
+      ...routeGroups,
     ])
   })
 }

--- a/startos/versions/v2026.5.0.ts
+++ b/startos/versions/v2026.5.0.ts
@@ -1,7 +1,7 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const v2026_5_0 = VersionInfo.of({
-  version: '2026.5.0:0',
+  version: '2026.5.0:1',
   releaseNotes: {
     en_US: 'Updated to cloudflared 2026.5.0',
     es_ES: 'Actualizado a cloudflared 2026.5.0',


### PR DESCRIPTION
Flattens application routes directly under each DNS zone group instead of nesting them inside an 'Application Routes' subgroup. This simplifies the hierarchy in the Managed Public Routes overview action.

**Changes:**
- Remove the nested `Application Routes` group wrapper; spread route groups directly under the zone group
- Bump version to `2026.5.0:1`